### PR TITLE
update SDKMAN! caching setup

### DIFF
--- a/travis/default.yml
+++ b/travis/default.yml
@@ -16,6 +16,7 @@ before_install:
 
 before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - rm -fv $HOME/.sdkman/var/broadcast_id
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
 


### PR DESCRIPTION
because I noticed this in one of our repos:
  store build cache
  changes detected (content changed, file is created, or file is deleted):\n/home/travis/.sdkman/var/broadcast
  /home/travis/.sdkman/var/broadcast_id\n
  changes detected, packing new archive