### PR TITLE
Fix regex to find AdoptOpenJDK from SDKMAN list

### DIFF
--- a/travis/default.yml
+++ b/travis/default.yml
@@ -6,7 +6,7 @@ before_install:
     echo sdkman_auto_answer=true > $HOME/.sdkman/etc/config
     echo sdkman_auto_selfupdate=true >> $HOME/.sdkman/etc/config
     source $HOME/.sdkman/bin/sdkman-init.sh
-    sdkJava=$(sdk list java | grep -o " $ADOPTOPENJDK\.[0-9\.]*hs-adpt" | head -1 | cut -c2-)
+    sdkJava=$(sdk list java | grep -o " $ADOPTOPENJDK\.[0-9]*\.[0-9]*\.hs-adpt" | head -1 | cut -c2-)
     sdk install java $sdkJava || true # install fails if it's already installed
     sdk use java $sdkJava
     unset JAVA_HOME


### PR DESCRIPTION
Since `11.0.8.hs` came out the existing regex to pick JDK 8 ends up picking
non-existing `8.hs-adpt`. The fixed regex should select `8.0.265.hs-adpt` etc correctly.