### PR TITLE
Scala 2.13.10 release notes draft

### DIFF
--- a/2.13.10.md
+++ b/2.13.10.md
@@ -6,8 +6,8 @@ The following changes are highlights of this release:
 
 ### Regressions fixed
 
-* Fix 2.13.9 regression which broke binary compatibility of case classes which are also value classes ([#10155](https://github.com/scala/scala/pull/10155)
-* Fix 2.13.9 regression in linting, causing spurious "variable x is never used" warnings ([#10154](https://github.com/scala/scala/pull/10154)
+* Fix 2.13.9 regression which broke binary compatibility of case classes which are also value classes ([#10155](https://github.com/scala/scala/pull/10155))
+* Fix 2.13.9 regression in linting, causing spurious "variable x is never used" warnings ([#10154](https://github.com/scala/scala/pull/10154))
 
 ### Other notable changes
 

--- a/2.13.10.md
+++ b/2.13.10.md
@@ -1,0 +1,46 @@
+# Scala 2.13.10 (DRAFT)
+
+The Scala team at Lightbend is pleased to announce the availability of Scala 2.13.10.
+
+The following changes are highlights of this release:
+
+### Regressions fixed
+
+* Fix 2.13.9 regression which broke binary compatibility of case classes which are also value classes ([#10155](https://github.com/scala/scala/pull/10155)
+* Fix 2.13.9 regression in linting, causing spurious "variable x is never used" warnings ([#10154](https://github.com/scala/scala/pull/10154)
+
+### Other notable changes
+
+* `-Xsource:3` now respects refinements by whitebox macro overrides ([#10160](https://github.com/scala/scala/pull/10160) by [@som-snytt](https://github.com/som-snytt))
+* Scaladoc tool: fix parsing bug which could cause very slow performance or incorrect output ([#10175](https://github.com/scala/scala/pull/10175) by [@liang3zy22](https://github.com/liang3zy22))
+* Restore `-Vprint-args`, for echoing arguments provided to compiler ([#10164](https://github.com/scala/scala/pull/10164) by [@som-snytt](https://github.com/som-snytt))
+
+For the complete 2.13.10 change lists, see [all merged PRs](https://github.com/scala/scala/pulls?q=is%3Amerged%20milestone%3A2.13.10) and [all closed bugs](https://github.com/scala/bug/issues?utf8=%E2%9C%93&q=is%3Aclosed+milestone%3A2.13.10).
+
+## Compatibility
+
+As usual for our minor releases, Scala 2.13.10 is [binary-compatible](https://docs.scala-lang.org/overviews/core/binary-compatibility-of-scala-releases.html) with the whole Scala 2.13 series.
+
+Upgrading from 2.12? Enable `-Xmigration` while upgrading to request migration advice from the compiler.
+
+## Contributors
+
+A big thank you to everyone who's helped improve Scala by reporting bugs, improving our documentation, spreading kindness in discussions around Scala, and submitting and reviewing pull requests! You are all magnificent.
+
+We especially acknowledge and thank A. P. Marki, also known as Som Snytt, who is responsible for an especially large share of the improvements in this release.
+
+This release was brought to you by 27 contributors, according to `git shortlog -sn --no-merges @ ^v2.13.8 ^2.12.x`. Thank you A. P. Marki, Liang Yan, Seth Tisue, Antoine Parent, Luc Henninger, liang3zy22, 梦境迷离.
+
+Thanks to [Lightbend](https://www.lightbend.com/scala) for their continued sponsorship of the Scala core team’s efforts. Lightbend offers [commercial support](https://www.lightbend.com/lightbend-platform-subscription) for Scala.
+
+## Scala 2.13 notes
+
+The [release notes for Scala 2.13.0](https://github.com/scala/scala/releases/v2.13.0) have important information applicable to the whole 2.13 series.
+
+## Obtaining Scala
+
+Scala releases are available through a variety of channels, including (but not limited to):
+
+* Bump the `scalaVersion` setting in your sbt-based project
+* Download a distribution from [scala-lang.org](https://scala-lang.org/download/2.13.10.html)
+* Obtain JARs via [Maven Central](https://search.maven.org/search?q=g:org.scala-lang%20AND%20v:2.13.10)

--- a/2.13.10.md
+++ b/2.13.10.md
@@ -29,7 +29,7 @@ A big thank you to everyone who's helped improve Scala by reporting bugs, improv
 
 We especially acknowledge and thank A. P. Marki, also known as Som Snytt, who is responsible for an especially large share of the improvements in this release.
 
-This release was brought to you by 27 contributors, according to `git shortlog -sn --no-merges @ ^v2.13.8 ^2.12.x`. Thank you A. P. Marki, Liang Yan, Seth Tisue, Antoine Parent, Luc Henninger, liang3zy22, 梦境迷离.
+This release was brought to you by 7 contributors, according to `git shortlog -sn --no-merges @ ^v2.13.8 ^2.12.x`. Thank you A. P. Marki, Liang Yan, Seth Tisue, Antoine Parent, Luc Henninger, liang3zy22, 梦境迷离.
 
 Thanks to [Lightbend](https://www.lightbend.com/scala) for their continued sponsorship of the Scala core team’s efforts. Lightbend offers [commercial support](https://www.lightbend.com/lightbend-platform-subscription) for Scala.
 

--- a/2.13.10.md
+++ b/2.13.10.md
@@ -29,7 +29,7 @@ A big thank you to everyone who's helped improve Scala by reporting bugs, improv
 
 We especially acknowledge and thank A. P. Marki, also known as Som Snytt, who is responsible for an especially large share of the improvements in this release.
 
-This release was brought to you by 7 contributors, according to `git shortlog -sn --no-merges @ ^v2.13.8 ^2.12.x`. Thank you A. P. Marki, Liang Yan, Seth Tisue, Antoine Parent, Luc Henninger, liang3zy22, 梦境迷离.
+This release was brought to you by 6 contributors, according to `git shortlog -sn --no-merges @ ^v2.13.9 ^2.12.x`. Thank you A. P. Marki, Liang Yan, Seth Tisue, Antoine Parent, Luc Henninger, 梦境迷离.
 
 Thanks to [Lightbend](https://www.lightbend.com/scala) for their continued sponsorship of the Scala core team’s efforts. Lightbend offers [commercial support](https://www.lightbend.com/lightbend-platform-subscription) for Scala.
 


### PR DESCRIPTION
[link to rendered version](https://github.com/SethTisue/scala-dev/blob/scala-2.13.10-release-notes/2.13.10.md)

Feedback welcome