### PR TITLE
adjust release steps now that Scala 3 has its own stdlib

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -203,11 +203,10 @@ If there are delays downstream, at some point it may make sense to go ahead and 
 ### Afterwards
 
 - [ ] sbt: if it's a 2.12.x release, open PR updating version
-- [ ] Scala 3: open PR updating version:
-  - two places to update:
-    - `project/Build.scala`
-    - `community-build/community-projects/stdLib213` (after updating https://github.com/dotty-staging/scala to the release tag)
-  - https://github.com/scala/scala3/pulls
+- [ ] Scala 3: open draft PR updating version in `project/ScalaLibraryPlugin.scala`
+  - the PR won't be mergeable on its own because someone will need to run the script
+    that syncs standard library sources, but the PR will serve as a reminder that
+    somebody from the Scala 3 team needs to do that
 - [ ] Scastie: open PR adding new version (modeled on https://github.com/scalacenter/scastie/pull/538)
   - note that the PR won't be mergeable until kind-projector has published; and if kind-projector's version number has changed, `ScalaTarget.scala` will need updating
 - ~If it's a major release:~

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -203,10 +203,7 @@ If there are delays downstream, at some point it may make sense to go ahead and 
 ### Afterwards
 
 - [ ] sbt: if it's a 2.12.x release, open PR updating version
-- [ ] Scala 3: open draft PR updating version in `project/ScalaLibraryPlugin.scala`
-  - the PR won't be mergeable on its own because someone will need to run the script
-    that syncs standard library sources, but the PR will serve as a reminder that
-    somebody from the Scala 3 team needs to do that
+- [ ] Scala 3: open issue suggesting that the Scala 3 stdlib merge our changes to the stdlib sources and tag `@scala/stdlib-officers`
 - [ ] Scastie: open PR adding new version (modeled on https://github.com/scalacenter/scastie/pull/538)
   - note that the PR won't be mergeable until kind-projector has published; and if kind-projector's version number has changed, `ScalaTarget.scala` will need updating
 - ~If it's a major release:~


### PR DESCRIPTION
@WojciechMazur is this what the Scala 2 release steps should say now?

or we just omit this bullet entirely and assume that it will be taken care of by the Scala 3 team?